### PR TITLE
A better re for the functions definitions.

### DIFF
--- a/parser/functions.py
+++ b/parser/functions.py
@@ -8,8 +8,7 @@ from flexicon import FlexiconError, Lexer
 
 EXPRESSION_LEXER = Lexer().simple(
     (r'[ \t]+', lambda: None),
-    #(r'(\w?  \w+\(\w+\)\s*=    lambda fun, var: ('FUNCTION', fun, var)),
-    (r'.*\w?\=\w?', lambda: None),  # e.g:'f(x) = '
+    (r'[a-zA-Z]+ *\( *[a-zA-Z] *(, *[a-zA-Z] *)*\)\s*=', lambda: None),  # e.g:'f(x) = ' or 'f( x, y, z) ='
     (r'\+', lambda: ('ADD',)),
     (r'\/', lambda: ('DIVIDE',)),
     (r'\-', lambda: ('SUBTRACT',)),

--- a/parser/functions.py
+++ b/parser/functions.py
@@ -8,6 +8,7 @@ from flexicon import FlexiconError, Lexer
 
 EXPRESSION_LEXER = Lexer().simple(
     (r'[ \t]+', lambda: None),
+    #(r'(\w?  \w+\(\w+\)\s*=    lambda fun, var: ('FUNCTION', fun, var)),
     (r'.*\w?\=\w?', lambda: None),  # e.g:'f(x) = '
     (r'\+', lambda: ('ADD',)),
     (r'\/', lambda: ('DIVIDE',)),


### PR DESCRIPTION
The r'.*\w?\=\w?' re match mutch things like:
f(x)=x ; sasasaa = ; and others
This new does't match whi this tings.
You can see the tests here:
Old - [http://regexr.com/3g14a](http://regexr.com/3g14a)
New - [http://regexr.com/3g147](http://regexr.com/3g147)
